### PR TITLE
Feature/throw on assist init fail

### DIFF
--- a/src/libraries/assist.js
+++ b/src/libraries/assist.js
@@ -215,7 +215,7 @@ export function getAssist(web3) {
   }
 
   const assistConfig = {
-    networkId: process.env.REACT_APP_NETWORK_ID || 1,
+    networkId: Number(process.env.REACT_APP_NETWORK_ID) || 1,
     dappId: '12153f55-f29e-4f11-aa07-90f10da5d778',
     web3,
     messages: {

--- a/src/pages/App.js
+++ b/src/pages/App.js
@@ -22,7 +22,7 @@ class App extends Component {
       }
 
       getAssist(this.props.web3)
-    }).catch(console.log);
+    }).catch((e) => {throw e});
   };
 
   componentWillUpdate() {


### PR DESCRIPTION
@aaronbarnardsound does this make sense? otherwise it tries to create a websocket connection when the dappId might not be set